### PR TITLE
Issues/15 auto reconnect to producer node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /logs
 /composer.lock
 /phpunit.xml
+/composer.phar
 /.idea
 /vimrc
 /tags

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ $cache = new FileCache('/tmp/nodes');
 $stream = new CachedPool(['tcp://127.0.0.1:7711'], $cache);
 ```
 
+## Testing
+
+You can run the tests in docker `>1.10.0` using docker-compose.
+
+```
+# assuming you have setup composer dependencies, e.g.
+# docker run -v $PWD:/p -w /p php:7 ./composer.phar install
+docker-compose run vendor/bin/phpunit -c phpunit.xml.dist
+```
 
 # License
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     ],
     "require": {
         "php": ">=5.5",
-        "psr/log": "~1.0"
+        "psr/log": "~1.0",
+        "symfony/event-dispatcher": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2"
+services:
+    cli:
+        image: php:7
+        volumes:
+            - .:/p
+        working_dir: /p
+        links:
+            - disque
+        depends_on:
+            - disque
+    disque:
+        image: 0x20h/disque

--- a/phpunit.xml.docker
+++ b/phpunit.xml.docker
@@ -20,7 +20,7 @@
 		  </testsuite>
 	 </testsuites>
 	 <php>
-		<env name="DISQUE_SERVERS" value="tcp://127.0.0.1:7711" />
+		<env name="DISQUE_SERVERS" value="tcp://disque_1:7711,tcp://disque_2:7711,tcp://disque_3:7711" />
 		<env name="LOGFILE" value="./logs/tests.log" />
 	 </php>
 </phpunit>

--- a/src/Event/GetJobsEvent.php
+++ b/src/Event/GetJobsEvent.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jan.kohlhof
- * Date: 22.02.16
- * Time: 00:20
- */
 
 namespace Phloppy\Event;
 

--- a/src/Event/GetJobsEvent.php
+++ b/src/Event/GetJobsEvent.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jan.kohlhof
+ * Date: 22.02.16
+ * Time: 00:20
+ */
+
+namespace Phloppy\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class GetJobsEvent extends Event
+{
+
+    const ID = 'job.getjob';
+
+    /**
+     * @var string[]
+     */
+    private $queues;
+
+
+    /**
+     * @param string[] $queues
+     * @param          $count
+     * @param          $timeout
+     */
+    public function __construct(array $queues, $count, $timeout)
+    {
+        $this->queues = $queues;
+    }
+
+
+    /**
+     * @return string[]
+     */
+    public function getQueues()
+    {
+        return $this->queues;
+    }
+
+}

--- a/src/Event/JobsReceivedEvent.php
+++ b/src/Event/JobsReceivedEvent.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jan.kohlhof
- * Date: 22.02.16
- * Time: 00:20
- */
 
 namespace Phloppy\Event;
 

--- a/src/Event/JobsReceivedEvent.php
+++ b/src/Event/JobsReceivedEvent.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jan.kohlhof
+ * Date: 22.02.16
+ * Time: 00:20
+ */
+
+namespace Phloppy\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class JobsReceivedEvent extends Event
+{
+    const ID = 'job.getjob';
+
+    /**
+     * @var Job[]
+     */
+    private $jobs;
+
+    /**
+     * @var string[]
+     */
+    private $queues;
+
+
+    /**
+     * @param string[] $queues
+     * @param Job[] $jobs
+     */
+    public function __construct(array $queues, array $jobs)
+    {
+        $this->queues = $queues;
+        $this->jobs = $jobs;
+    }
+
+
+    /**
+     * @return Job[]
+     */
+    public function getJobs()
+    {
+        return $this->jobs;
+    }
+
+
+    /**
+     * @return string[]
+     */
+    public function getQueues()
+    {
+        return $this->queues;
+    }
+
+}

--- a/src/Job.php
+++ b/src/Job.php
@@ -1,11 +1,12 @@
 <?php
 namespace Phloppy;
 
-class Job {
+class Job
+{
 
-    const STATE_ACTIVE       = 'active';
-    const STATE_WAIT_REPL    = 'wait-repl';
-    const STATE_QUEUED       = 'queued';
+    const STATE_ACTIVE = 'active';
+    const STATE_WAIT_REPL = 'wait-repl';
+    const STATE_QUEUED = 'queued';
     const STATE_ACKNOWLEDGED = 'acknowledged';
 
     /**
@@ -15,14 +16,12 @@ class Job {
      */
     private $id = '';
 
-
     /**
      * Queue name this job was fetched from.
      *
      * @var string
      */
     private $queue = '';
-
 
     /**
      * Job body.
@@ -31,14 +30,12 @@ class Job {
      */
     private $body = '';
 
-
     /**
      * Delay time (before putting the job into the queue, in seconds).
      *
      * @var int
      */
     private $delay = 0;
-
 
     /**
      * Retry time (seconds).
@@ -49,7 +46,6 @@ class Job {
      * @var int
      */
     private $retry = 120;
-
 
     /**
      * The expire time (in seconds).
@@ -78,6 +74,7 @@ class Job {
         return $this->id;
     }
 
+
     /**
      * @param string $id
      */
@@ -85,6 +82,7 @@ class Job {
     {
         $this->id = $id;
     }
+
 
     /**
      * @return string
@@ -94,6 +92,7 @@ class Job {
         return $this->body;
     }
 
+
     /**
      * @return int
      */
@@ -102,13 +101,15 @@ class Job {
         return $this->delay;
     }
 
+
     /**
      * @param int $delay
      */
     public function setDelay($delay)
     {
-        $this->delay = (int) $delay;
+        $this->delay = (int)$delay;
     }
+
 
     /**
      * @return int
@@ -118,6 +119,7 @@ class Job {
         return $this->retry;
     }
 
+
     /**
      * @param int $retry
      */
@@ -125,6 +127,7 @@ class Job {
     {
         $this->retry = $retry;
     }
+
 
     /**
      * @return int
@@ -134,6 +137,7 @@ class Job {
         return $this->ttl;
     }
 
+
     /**
      * @param mixed $ttl
      */
@@ -142,6 +146,7 @@ class Job {
         $this->ttl = $ttl;
     }
 
+
     /**
      * @return string
      */
@@ -149,6 +154,7 @@ class Job {
     {
         return $this->queue;
     }
+
 
     /**
      * @param string $queue
@@ -160,9 +166,21 @@ class Job {
 
 
     /**
+     * Retrieve the originating node id.
+     *
+     * @return string|null The node id of the node where the job was published
+     */
+    public function getOriginNode()
+    {
+        return $this->id ? substr($this->id, 3, 11) : null;
+    }
+
+
+    /**
      * Job Factory method.
      *
      * @param array $args
+     *
      * @return Job
      */
     public static function create(array $args)
@@ -189,15 +207,6 @@ class Job {
         return $job;
     }
 
-    /**
-     * Retrieve the originating node id.
-     *
-     * @return string|null The node id of the node where the job was published
-     */
-    public function getOriginNode()
-    {
-        return $this->id ? substr($this->id, 2, 8) : null;
-    }
 
     public function __toString()
     {

--- a/src/Job.php
+++ b/src/Job.php
@@ -172,7 +172,7 @@ class Job
      */
     public function getOriginNode()
     {
-        return $this->id ? substr($this->id, 3, 11) : null;
+        return $this->id ? substr($this->id, 2, 8) : null;
     }
 
 

--- a/src/Statistic/JobOriginStatistic.php
+++ b/src/Statistic/JobOriginStatistic.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Phloppy\Statistic;
+
+use Phloppy\Exception;
+use Phloppy\Job;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class JobOriginStatistic implements NodeStatistic
+{
+
+    const ALPHA = 0.9;
+
+    /**
+     * Node Ids
+     *
+     * @var \DateTime[]
+     */
+    private $lastReceived;
+
+    /**
+     * @var float[]
+     */
+    private $stats;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $log;
+
+    function __construct(LoggerInterface $log = null)
+    {
+        if (!$log) {
+            $log = new NullLogger();
+        }
+
+        $this->log = $log;
+    }
+
+
+    /**
+     * Update jobs by node/sec rt-statistic.
+     *
+     * @param Job       $job
+     *
+     * @param \DateTime $receivedAt
+     *
+     * @return float messages/sec from the given node
+     */
+    public function update(Job $job, \DateTime $receivedAt = null)
+    {
+        $nodeId = $job->getOriginNode();
+
+        if (!$receivedAt) {
+            $receivedAt = new \DateTime('now');
+        }
+
+        if (!isset($this->lastReceived[$nodeId])) {
+            $this->lastReceived[$nodeId] = clone $receivedAt;
+        }
+
+        if (!isset($this->stats[$nodeId])) {
+            $this->stats[$nodeId] = 0.;
+        }
+
+        $secs = $receivedAt->diff($this->lastReceived[$nodeId])->s;
+
+        if ($secs < 0) {
+            $secs = 0;
+        }
+
+        $this->lastReceived[$nodeId] = clone $receivedAt;
+        // exp moving average from the last message to now (per sec)
+        $this->stats[$nodeId] =
+            pow(self::ALPHA, $secs) * $this->stats[$nodeId] +
+            (1 - self::ALPHA);
+
+        $this->log->debug('updated value', ['id' => $nodeId, 'pow' => pow(self::ALPHA, $secs), 'value' => $this->stats[$nodeId], 'delta' => $secs]);
+        return $this->stats[$nodeId];
+    }
+
+
+    /**
+     * Return an ordered list of nodes.
+     *
+     * The list is ordered descending by the frequency of Jobs.
+     *
+     * @return float[]
+     */
+    public function nodes()
+    {
+        return $this->stats;
+    }
+
+
+    /**
+     * Return information on a specific node.
+     *
+     * If the node is not known, no messages have been retrieved from it, so 0. will be returned.
+     *
+     * @param $nodeId
+     *
+     * @return float
+     */
+    public function node($nodeId)
+    {
+        return isset($this->stats[$nodeId]) ? $this->stats[$nodeId] : 0.;
+    }
+}

--- a/src/Statistic/JobOriginStatistic.php
+++ b/src/Statistic/JobOriginStatistic.php
@@ -101,11 +101,11 @@ class JobOriginStatistic implements NodeStatistic
         $this->log->debug('updated value', [
             'id' => $nodeId,
             'queue' => $queue,
-            'value' => $this->stats[$nodeId],
+            'value' => $this->stats[$queue][$nodeId],
             'delta' => $secs
         ]);
 
-        return $this->stats[$nodeId];
+        return $this->stats[$queue][$nodeId];
     }
 
 

--- a/src/Statistic/NodeStatistic.php
+++ b/src/Statistic/NodeStatistic.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Phloppy\Statistic;
+
+use Phloppy\Job;
+
+interface NodeStatistic
+{
+
+    /**
+     * Update node stats by providing a Job.
+     *
+     * @param Job       $job
+     *
+     * @param \DateTime $receivedAt
+     *
+     * @return float messages/sec from the node that produced the job
+     */
+    public function update(Job $job, \DateTime $receivedAt = null);
+
+
+    /**
+     * Return an ordered list of nodes.
+     *
+     * The list is ordered descending by the frequency of Jobs.
+     *
+     * @return float[]
+     */
+    public function nodes();
+
+
+    /**
+     * Return information on a specific node.
+     *
+     * If the node is not known, no messages have been retrieved from it, so 0. will be returned.
+     *
+     * @param $nodeId
+     *
+     * @return float
+     */
+    public function node($nodeId);
+}

--- a/src/Statistic/NodeStatistic.php
+++ b/src/Statistic/NodeStatistic.php
@@ -20,13 +20,14 @@ interface NodeStatistic
 
 
     /**
-     * Return an ordered list of nodes.
+     * Return an ordered list of nodes for the given queue.
      *
-     * The list is ordered descending by the frequency of Jobs.
+     * The list is ordered descending by the frequency of Jobs received from the
+     * respective node.
      *
-     * @return float[]
+     * @return string[]
      */
-    public function nodes();
+    public function nodes($queue);
 
 
     /**
@@ -38,5 +39,5 @@ interface NodeStatistic
      *
      * @return float
      */
-    public function node($nodeId);
+    public function node($nodeId, $queue);
 }

--- a/src/Subscriber/MessageRateStreamSelector.php
+++ b/src/Subscriber/MessageRateStreamSelector.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jan.kohlhof
- * Date: 22.02.16
- * Time: 00:52
- */
 
 namespace Phloppy\Subscriber;
 

--- a/src/Subscriber/MessageRateStreamSelector.php
+++ b/src/Subscriber/MessageRateStreamSelector.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jan.kohlhof
+ * Date: 22.02.16
+ * Time: 00:52
+ */
+
+namespace Phloppy\Subscriber;
+
+use Phloppy\Client\AbstractClient;
+use Phloppy\Event\GetJobsEvent;
+use Phloppy\Event\JobsReceivedEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class MessageRateStreamSelector implements EventSubscriberInterface
+{
+    public function __construct(AbstractClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            GetJobsEvent::ID => 'selectOptimalNode',
+            JobsReceivedEvent::ID => 'updateNodeStats'
+        ];
+    }
+}

--- a/tests/unit/Statistic/JobOriginStatisticTest.php
+++ b/tests/unit/Statistic/JobOriginStatisticTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Phloppy\Statistic;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use Psr\Log\LoggerInterface;
+
+class JobOriginStatisticTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @var LoggerInterface
+     */
+    private $log;
+
+    protected function setUp()
+    {
+        $this->log = new Logger(new StreamHandler('php://stdout'));
+    }
+
+
+    public function testNode()
+    {
+        $job = $this->getMockBuilder('Phloppy\Job')
+            ->setConstructorArgs(['body'])
+            ->getMock();
+
+        $job->expects($this->any())
+            ->method('getOriginNode')
+            ->willReturn('a');
+
+        $statistics = new JobOriginStatistic($this->log);
+
+        // lets assume that in 10 subsequent seconds one message is received per second
+        $date = new \DateTime('now');
+
+        for ($i = 0; $i < 10; $i++) {
+            $statistics->update($job, $date);
+            $date = $date->add(new \DateInterval('PT1S'));
+        }
+
+        // Statistics should be around 1. (per sec)
+        $this->assertLessThan(.001, 1 - $statistics->node('a'));
+    }
+
+
+    public function testNodes()
+    {
+        $jobA = $this->getMockBuilder('Phloppy\Job')
+            ->setConstructorArgs(['body'])
+            ->getMock();
+
+        $jobB = clone $jobA;
+
+        $jobA->expects($this->any())
+            ->method('getOriginNode')
+            ->willReturn('a');
+
+        $jobB->expects($this->any())
+            ->method('getOriginNode')
+            ->willReturn('b');
+
+        $statistics = new JobOriginStatistic($this->log);
+
+        // lets assume that in 10 subsequent seconds one message is received per second
+        $dateA = new \DateTime('now');
+        // lets assume that in 20 subsequent seconds one message is received every second second
+        $dateB = new \DateTime('now');
+
+        for ($i = 0; $i < 200; $i++) {
+            $statistics->update($jobA, $dateA);
+            $statistics->update($jobB, $dateB);
+            $dateA = $dateA->add(new \DateInterval('PT1S'));
+            $dateB = $dateB->add(new \DateInterval('PT2S'));
+        }
+
+        // Statistics should be around 1. (per sec)
+        $this->assertLessThan(.001, 1. - $statistics->node('a'));
+        // Statistics should be around .5 (per sec)
+        $this->assertLessThan(.001, .5 - $statistics->node('b'));
+    }
+}

--- a/tests/unit/Statistic/JobOriginStatisticTest.php
+++ b/tests/unit/Statistic/JobOriginStatisticTest.php
@@ -5,6 +5,7 @@ namespace Phloppy\Statistic;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class JobOriginStatisticTest extends \PHPUnit_Framework_TestCase
 {
@@ -14,9 +15,38 @@ class JobOriginStatisticTest extends \PHPUnit_Framework_TestCase
      */
     private $log;
 
+
     protected function setUp()
     {
         $this->log = new Logger(new StreamHandler('php://stdout'));
+        $this->log = new NullLogger();
+    }
+
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testTooSmallAlpha()
+    {
+        new JobOriginStatistic(.4);
+    }
+
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testTooLargeAlpha()
+    {
+        new JobOriginStatistic(1.2);
+    }
+
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidAlpha()
+    {
+        new JobOriginStatistic('foo');
     }
 
 
@@ -30,12 +60,12 @@ class JobOriginStatisticTest extends \PHPUnit_Framework_TestCase
             ->method('getOriginNode')
             ->willReturn('a');
 
-        $statistics = new JobOriginStatistic($this->log);
+        $statistics = new JobOriginStatistic(.8, $this->log);
 
         // lets assume that in 10 subsequent seconds one message is received per second
         $date = new \DateTime('now');
 
-        for ($i = 0; $i < 10; $i++) {
+        for ($i = 0; $i < 50; $i++) {
             $statistics->update($job, $date);
             $date = $date->add(new \DateInterval('PT1S'));
         }
@@ -61,7 +91,7 @@ class JobOriginStatisticTest extends \PHPUnit_Framework_TestCase
             ->method('getOriginNode')
             ->willReturn('b');
 
-        $statistics = new JobOriginStatistic($this->log);
+        $statistics = new JobOriginStatistic(.8, $this->log);
 
         // lets assume that in 10 subsequent seconds one message is received per second
         $dateA = new \DateTime('now');


### PR DESCRIPTION
So, here's the TODOs:
- [x] create and trigger an event when fetching one or more new jobs 
- [x] create and trigger an event after one or more new jobs have been 
- [x] create functionality to store a msg/sec by node
- [x] create functionality to update the statistics (by node)
- [ ] create functionality to retrieve the node that we read most from at the moment
- [ ] create functionality to switch the connection if necessary before retrieving new jobs

I decided to implement this feature as a subscriber to the new events, so it's up to the user to enable this feature by adding the subscriber to the client.
